### PR TITLE
HDDS-13179. CI failure during flaky-test-check

### DIFF
--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -115,7 +115,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -267,11 +267,11 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
           <execution>
-            <id>rename-generated-test-config</id>
+            <id>copy-generated-test-config</id>
             <phase>process-test-classes</phase>
           </execution>
         </executions>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -268,7 +268,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -337,11 +337,11 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
           <execution>
-            <id>rename-generated-test-config</id>
+            <id>copy-generated-test-config</id>
             <phase>process-test-classes</phase>
           </execution>
         </executions>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -246,7 +246,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -192,7 +192,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -199,7 +199,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -388,7 +388,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -331,7 +331,7 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>rename-generated-config</id>
+            <id>copy-generated-config</id>
             <phase>process-classes</phase>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2179,14 +2179,14 @@
               If a new module is introduced with generated config:
               - override ban-annotations execution of maven-enforcer-plugin
               - configure maven-compiler-plugin with the ConfigFileGenerator annotationProcessor
-              - bind one or both of these rename executions
+              - bind one or both of these copy executions
               - add the module's name in OzoneConfiguration#activate
               See hadoop-hdds/common/pom.xml for example.
             -->
             <execution>
-              <id>rename-generated-config</id>
+              <id>copy-generated-config</id>
               <goals>
-                <goal>rename</goal>
+                <goal>copy</goal>
               </goals>
               <!-- bind to process-classes in modules where needed -->
               <phase>none</phase>
@@ -2200,9 +2200,9 @@
               </configuration>
             </execution>
             <execution>
-              <id>rename-generated-test-config</id>
+              <id>copy-generated-test-config</id>
               <goals>
-                <goal>rename</goal>
+                <goal>copy</goal>
               </goals>
               <!-- bind to process-test-classes in modules where needed -->
               <phase>none</phase>


### PR DESCRIPTION
## What changes were proposed in this pull request?

See the Maven error message:
```
Error:  Failed to execute goal com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1:rename (rename-generated-config) on project ozone-manager: sourceFile /home/runner/work/ozone/ozone/hadoop-ozone/ozone-manager/target/classes/ozone-default-generated.xml does not exist -> [Help 1]
843Error:  
844Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
845Error:  Re-run Maven using the -X switch to enable full debug logging.
846Error:  
847Error:  For more information about the errors and possible solutions, please read the following articles:
848Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException 
```

Fix flaky CI build where ozone-default-generated.xml was missing in the second mvn install run.
Changed the rename goal to copy in the copy-rename-maven-plugin to avoid failing when the file doesn’t exist yet.

## What is the link to the Apache JIRA

Please create an issue in ASF JIRA before opening a pull request, and you need to set the title of the pull
request which starts with the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
